### PR TITLE
Fix the Action to not create a .zip.zip file

### DIFF
--- a/.github/workflows/generate-gerbers.yaml
+++ b/.github/workflows/generate-gerbers.yaml
@@ -62,8 +62,26 @@ jobs:
     - name: Upload Export Files as Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: GreenMobi-BMS.zip
-        path: hardware/greenmobi-bms/
+        name: GreenMobi-BMS
+        path: | 
+          hardware/greenmobi-bms/
+          hardware/greenmobi-bms/*.pdf
+        if-no-files-found: error
+        retention-days: 60
+      
+    - name: Upload Schematic PDF as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Schematic.pdf
+        path: hardware/greenmobi-bms/Schematic.pdf
+        if-no-files-found: error
+        retention-days: 60
+
+    - name: Upload PCB PDF as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: PCB.pdf
+        path: hardware/greenmobi-bms/PCB.pdf
         if-no-files-found: error
         retention-days: 60
 

--- a/.github/workflows/generate-gerbers.yaml
+++ b/.github/workflows/generate-gerbers.yaml
@@ -65,7 +65,7 @@ jobs:
         name: GreenMobi-BMS
         path: | 
           hardware/greenmobi-bms/
-          hardware/greenmobi-bms/*.pdf
+          !hardware/greenmobi-bms/*.pdf
         if-no-files-found: error
         retention-days: 60
       

--- a/hardware/greenmobi-bms.kicad_sch
+++ b/hardware/greenmobi-bms.kicad_sch
@@ -536,7 +536,7 @@
 		(uuid "bf9ce823-20a6-4765-a026-481c03b10d1d")
 	)
 	(label "PACK+"
-		(at 43.18 88.9 0)
+		(at 44.45 88.9 0)
 		(fields_autoplaced yes)
 		(effects
 			(font

--- a/hardware/greenmobi-bms.kicad_sch
+++ b/hardware/greenmobi-bms.kicad_sch
@@ -536,7 +536,7 @@
 		(uuid "bf9ce823-20a6-4765-a026-481c03b10d1d")
 	)
 	(label "PACK+"
-		(at 44.45 88.9 0)
+		(at 43.18 88.9 0)
 		(fields_autoplaced yes)
 		(effects
 			(font


### PR DESCRIPTION
Previously, the results of the "Export ECAD" action were uploaded as an artifact with a .zip extension, even though they were not zipped. GitHub would then zip them again, creating an (actual) zip archive with a .zip.zip file extension. This PR fixes that, and uploads seperate artifacts for the two PDFs (which allows them to be used e.g. with [App Sharing Space](https://appsharing.space/static-app)).